### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,7 +1,5 @@
 {
-  "affected": {
-    "defaultBase": "origin/main"
-  },
+  "affected": { "defaultBase": "origin/main" },
   "stuff": [],
   "namedInputs": {
     "default": ["sharedGlobals", "{projectRoot}/**/*"],
@@ -24,16 +22,11 @@
         "outputPath": "dist/apps/{projectName}",
         "buildLibsFromSource": false
       },
-      "configurations": {
-        "production": {}
-      }
+      "configurations": { "production": {} }
     },
     "serve": {
       "executor": "@nx/next:server",
-      "options": {
-        "buildTarget": "{projectName}:build",
-        "dev": true
-      },
+      "options": { "buildTarget": "{projectName}:build", "dev": true },
       "configurations": {
         "production": {
           "buildTarget": "{projectName}:build:production",
@@ -46,9 +39,7 @@
       "cache": true,
       "inputs": ["production", "^production"],
       "outputs": ["{workspaceRoot}/dist/{projectRoot}/exported"],
-      "options": {
-        "buildTarget": "{projectName}:build:production"
-      }
+      "options": { "buildTarget": "{projectName}:build:production" }
     },
     "serve-static": {
       "dependsOn": ["export"],
@@ -66,9 +57,7 @@
       "cache": true,
       "inputs": ["default", "{workspaceRoot}/.eslintrc.json"],
       "executor": "@nx/eslint:lint",
-      "options": {
-        "lintFilePatterns": ["{projectRoot}/**/*.{ts,tsx,js,jsx}"]
-      }
+      "options": { "lintFilePatterns": ["{projectRoot}/**/*.{ts,tsx,js,jsx}"] }
     },
     "test": {
       "cache": true,
@@ -80,5 +69,7 @@
       }
     }
   },
-  "plugins": ["@nx/cypress/plugin"]
+  "plugins": ["@nx/cypress/plugin"],
+  "nxCloudAccessToken": "NjJlZTQ5ODMtZmI2NS00YWVmLWJhYmMtNGI2NWFlNzViNjU0fHJlYWQtd3JpdGU=",
+  "nxCloudUrl": "http://localhost:4202"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
http://localhost:4202/orgs/67ae289e25cdcb7e0b309584/workspaces/67d48347753f283eb3dbe493

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.